### PR TITLE
Support multiple accounts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
 sudo: false
 rvm:
-  - 1.9
   - 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: ruby
 sudo: false
 rvm:
   - 2.2
+branches:
+  only:
+    - master
+    - /\A\d-\d-stable\z/

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2013 Audee Velasco, Modern Message LLC
+Copyright (c) 2015 Sean Linsley, Modern Message LLC
 
 MIT License
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,21 @@
 
 Add this line to your application's Gemfile:
 
-    gem 'giftbit'
+```ruby
+gem 'giftbit'
+```
 
 And then execute:
 
-    $ bundle
+```
+bundle
+```
 
 Or install it yourself as:
 
-    $ gem install giftbit
+```
+gem install giftbit
+```
 
 ## Usage
 

--- a/giftbit.gemspec
+++ b/giftbit.gemspec
@@ -5,21 +5,22 @@ require 'giftbit/version'
 Gem::Specification.new do |spec|
   spec.name          = 'giftbit'
   spec.version       = Giftbit::VERSION
-  spec.authors       = ['Audee Velasco', 'Sean Linsley']
-  spec.email         = ['auds@adooylabs.com', 'sean@modernmsg.com']
+  spec.authors       = ['Sean Linsley']
+  spec.email         = ['sean@modernmsg.com']
   spec.summary       = 'A Ruby gem for the Giftbit API'
-  spec.homepage      = 'http://www.github.com/modernmsg/giftbit'
+  spec.homepage      = 'https://www.github.com/modernmsg/giftbit'
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($/)
   spec.test_files    = spec.files.grep(/spec\//)
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2'
 
   spec.add_dependency 'rest-client'
   spec.add_dependency 'activesupport'
 
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'pry'
 end

--- a/giftbit.gemspec
+++ b/giftbit.gemspec
@@ -3,23 +3,23 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'giftbit/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "giftbit"
+  spec.name          = 'giftbit'
   spec.version       = Giftbit::VERSION
-  spec.authors       = ["Audee Velasco", "Sean Linsley"]
-  spec.email         = ["auds@adooylabs.com", "sean@modernmsg.com"]
-  spec.summary       = "A Ruby gem for the Giftbit API"
-  spec.homepage      = "http://www.github.com/modernmsg/giftbit"
-  spec.license       = "MIT"
+  spec.authors       = ['Audee Velasco', 'Sean Linsley']
+  spec.email         = ['auds@adooylabs.com', 'sean@modernmsg.com']
+  spec.summary       = 'A Ruby gem for the Giftbit API'
+  spec.homepage      = 'http://www.github.com/modernmsg/giftbit'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files`.split($/)
   spec.test_files    = spec.files.grep(/spec\//)
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.required_ruby_version = ">= 1.9.3"
+  spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency "rest-client"
-  spec.add_dependency "activesupport"
+  spec.add_dependency 'rest-client'
+  spec.add_dependency 'activesupport'
 
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
 end

--- a/lib/giftbit.rb
+++ b/lib/giftbit.rb
@@ -1,10 +1,28 @@
 require 'giftbit/version'
 require 'giftbit/base'
 
-module Giftbit
-  include Giftbit::Base
+class Giftbit
+  extend Base
+  include Base
 
-  module ClassMethods
+  # Class-level methods only work if you have a single API account. This lets
+  # you instantiate the API for a given account, if you have multiple.
+  def initialize(auth:)
+    fail 'no auths set' unless auths = self.class.auths
+    self.auth = auths.fetch(auth)
+  end
+
+  # This lets you call the same API requests on every account you have.
+  # This is useful e.g. to check the status of every gift in every account.
+  def self.each_auth
+    fail 'no auths set' unless auths
+    auths.each do |name, key|
+      api = new auth: name
+      api.instance_exec{ yield }
+    end
+  end
+
+  module Methods
     def account
       get ''
     end
@@ -57,5 +75,6 @@ module Giftbit
     end
   end
 
-  extend ClassMethods
+  extend Methods
+  include Methods
 end

--- a/lib/giftbit.rb
+++ b/lib/giftbit.rb
@@ -21,6 +21,10 @@ class Giftbit
     end
   end
 
+  def ==(other)
+    other.is_a?(Giftbit) && auth == other.auth
+  end
+
   module Methods
     def account
       get ''

--- a/lib/giftbit.rb
+++ b/lib/giftbit.rb
@@ -4,34 +4,27 @@ require 'giftbit/base'
 module Giftbit
   include Giftbit::Base
 
-  # Convenience methods to interact with resources on top of Giftbit::Base
   module ClassMethods
-    # Root of resource returns account info
     def account
       get ''
     end
 
-    # Marketplace resource
     def marketplace(params = {})
       get 'marketplace', params: params
     end
 
-    # Regions resource
     def regions(params = {})
       get 'marketplace/regions', params: params
     end
 
-    # Vendors resource
     def vendors(params = {})
       get 'marketplace/vendors', params: params
     end
 
-    # Categories resource
     def categories(params = {})
       get 'marketplace/categories', params: params
     end
 
-    # Campaign resource
     def campaign(params = {})
       get 'campaign', params: params
     end
@@ -40,7 +33,6 @@ module Giftbit
       get 'gifts', params: params
     end
 
-    # Create a gift
     def create_gift(body = {})
       body[:expiry] ||= (Date.today + 365).to_s
       body[:quote] = body[:quote] != false
@@ -48,20 +40,16 @@ module Giftbit
       post 'campaign', body: body
     end
 
-
-    # Send a gift
     def send_gift(id)
       put "campaign/#{id}"
     end
 
-    # Delete a gift
     def delete_gift(id)
       delete "campaign/#{id}"
     end
 
-    # Re-send a gift email
     def resend_gift(gift_uuid)
-      put "gifts/#{gift_uuid}", body: { resend: true }
+      put "gifts/#{gift_uuid}", body: {resend: true}
     end
 
     def get_links(campaign_id)

--- a/lib/giftbit.rb
+++ b/lib/giftbit.rb
@@ -16,9 +16,8 @@ class Giftbit
   # This is useful e.g. to check the status of every gift in every account.
   def self.each_auth
     fail 'no auths set' unless auths
-    auths.each do |name, key|
-      api = new auth: name
-      api.instance_exec{ yield }
+    auths.each do |name, _|
+      yield new auth: name
     end
   end
 

--- a/lib/giftbit/base.rb
+++ b/lib/giftbit/base.rb
@@ -1,61 +1,90 @@
 require 'active_support'
 require 'rest-client'
 
-module Giftbit
+class Giftbit
   module Base
-    def self.included(klass)
-      klass.extend ClassMethods
-
-      klass.endpoint ||= 'https://testbedapp.giftbit.com/papi/v1/'
-      klass.auth     ||= ''
+    def self.extended(klass)
+      klass.send :cattr_accessor, :endpoint, :auth, :auths
+      klass.endpoint = 'https://testbedapp.giftbit.com/papi/v1/'
     end
 
-    module ClassMethods
-      attr_accessor :endpoint, :auth
+    def self.included(klass)
+      klass.send :attr_accessor, :auth
+    end
 
-      def default_resource_options
-        {
-          headers: {
-            "Authorization" => "Bearer #{@auth}",
-            "Accept"        => "application/json",
-            "Content-Type"  => "json"
-          }
+    def get_auth
+      fail "auth and auths can't both be set" if inherited_auth && auths?
+
+      if auth = instance? ? self.auth : inherited_auth
+        auth
+      elsif auths?
+        fail 'you must init a new API instance with the auth you want to use'
+      else
+        fail 'you must set an auth token at application boot'
+      end
+    end
+
+    def inherited_auth
+      instance? ? self.class.auth : auth
+    end
+
+    def inherited_endpoint
+      instance? ? self.class.endpoint : endpoint
+    end
+
+    def auths?
+      auths = instance? ? self.class.auths : self.auths
+      auths && auths.any?
+    end
+
+    def instance?
+      self.class == Giftbit
+    end
+
+  private
+
+    def default_resource_options
+      {
+        headers: {
+          "Authorization" => "Bearer #{get_auth}",
+          "Accept"        => "application/json",
+          "Content-Type"  => "json"
         }
-      end
+      }
+    end
 
-      def resource(options = {})
-        RestClient::Resource.new @endpoint, default_resource_options.deep_merge(options)
-      end
+    def resource(options = {})
+      RestClient::Resource.new inherited_endpoint, default_resource_options.deep_merge(options)
+    end
 
-      def response(method, resource, options = {})
-        if body = options.delete(:body)
-          JSON.parse resource.send(method, JSON.generate(body), options)
-        else
-          JSON.parse resource.send(method, options)
-        end
-      rescue => e
-        if e.respond_to?(:response)
-          JSON.parse(e.response)
-        else
-          raise
-        end
+    def response(method, resource, options = {})
+      if body = options.delete(:body)
+        JSON.parse resource.send(method, JSON.generate(body), options)
+      else
+        JSON.parse resource.send(method, options)
       end
+    rescue => e
+      if e.respond_to?(:response)
+        JSON.parse(e.response)
+      else
+        raise
+      end
+    end
 
-      def get(path, request_options = {}, resource_options = {})
-        response :get, resource(resource_options)[path], request_options
-      end
+    def get(path, request_options = {}, resource_options = {})
+      response :get, resource(resource_options)[path], request_options
+    end
 
-      def delete(path, request_options = {}, resource_options = {})
-        response :delete, resource(resource_options)[path], request_options
-      end
+    def delete(path, request_options = {}, resource_options = {})
+      response :delete, resource(resource_options)[path], request_options
+    end
 
-      def post(path, request_options = {}, resource_options = {})
-        response :post, resource(resource_options)[path], request_options
-      end
+    def post(path, request_options = {}, resource_options = {})
+      response :post, resource(resource_options)[path], request_options
+    end
 
-      def put(path, request_options = {}, resource_options = {})
-        response :put, resource(resource_options)[path], request_options
-      end
+    def put(path, request_options = {}, resource_options = {})
+      response :put, resource(resource_options)[path], request_options
     end
   end
 end

--- a/lib/giftbit/base.rb
+++ b/lib/giftbit/base.rb
@@ -6,16 +6,13 @@ module Giftbit
     def self.included(klass)
       klass.extend ClassMethods
 
-      # By default, set the endpoint to testing
-      klass.endpoint  ||= 'https://testbedapp.giftbit.com/papi/v1/'
-      # By default, set the auth token to be empty
-      klass.auth      ||= ''
+      klass.endpoint ||= 'https://testbedapp.giftbit.com/papi/v1/'
+      klass.auth     ||= ''
     end
 
     module ClassMethods
       attr_accessor :endpoint, :auth
 
-      # Default resources options included in each request below
       def default_resource_options
         {
           headers: {
@@ -26,48 +23,38 @@ module Giftbit
         }
       end
 
-      # Convenience method for building a RestClient::Resource
       def resource(options = {})
         RestClient::Resource.new @endpoint, default_resource_options.deep_merge(options)
       end
 
-      # Convenience method for parsing and error handling a request
       def response(method, resource, options = {})
-        body = options.delete(:body)
-
-        if body.nil?
-          response = resource.send(method, *[options])
+        if body = options.delete(:body)
+          JSON.parse resource.send(method, JSON.generate(body), options)
         else
-          response = resource.send(method, *[JSON.generate(body), options])
+          JSON.parse resource.send(method, options)
         end
-
-        JSON.parse(response)
       rescue => e
         if e.respond_to?(:response)
           JSON.parse(e.response)
         else
-          raise e
+          raise
         end
       end
 
-      # GET (parsed) response from resources
       def get(path, request_options = {}, resource_options = {})
-        response(:get, resource(resource_options)[path], request_options)
+        response :get, resource(resource_options)[path], request_options
       end
 
-      # DELETE (parsed) response from resources
       def delete(path, request_options = {}, resource_options = {})
-        response(:delete, resource(resource_options)[path], request_options)
+        response :delete, resource(resource_options)[path], request_options
       end
 
-      # POST (parsed) response from resources
       def post(path, request_options = {}, resource_options = {})
-        response(:post, resource(resource_options)[path], request_options)
+        response :post, resource(resource_options)[path], request_options
       end
 
-      # PUT (parsed) response from resources
       def put(path, request_options = {}, resource_options = {})
-        response(:put, resource(resource_options)[path], request_options)
+        response :put, resource(resource_options)[path], request_options
       end
     end
   end

--- a/lib/giftbit/version.rb
+++ b/lib/giftbit/version.rb
@@ -1,3 +1,3 @@
 class Giftbit
-  VERSION = '0.0.1'
+  VERSION = '1.0.0'
 end

--- a/lib/giftbit/version.rb
+++ b/lib/giftbit/version.rb
@@ -1,3 +1,3 @@
-module Giftbit
-  VERSION = "0.0.1"
+class Giftbit
+  VERSION = '0.0.1'
 end

--- a/spec/giftbit_spec.rb
+++ b/spec/giftbit_spec.rb
@@ -1,222 +1,280 @@
-require "giftbit"
+require 'giftbit'
 
 describe Giftbit do
-  let(:auth) { "eyJ0eXAiOiJKV1QiLCJhbGciOiJTSEEyNTYifQ==.TFdWYU5VTVhzK3JFaVhHT2p5VDRHNFRsUk1ybnk2V2E4TDNDSW5meEdXdTVERUJNeHlDTEU1K216Qk1hb3Q4QlZaTVJvWndjR2ZoS01xc3gzdnZMUHdQckN1Z0kreG9rYVF3c1JjUjNkNlNLVmROQTlJb0hvMmpHdkx2REh3NXE=.cu7N3bPxGg8fPxFsIUcjyOISwn+29YpB0l7YDHwkMDg=" }
-  let(:endpoint ) { "https://testbedapp.giftbit.com/papi/v1/"}
-  let(:data) { {message: "Thank you for being an awesome person", subject: "Present from ModemMsg", contacts: [{firstname: "Audee", lastname: "Velasco", email: "auds@adooylabs.com"}], marketplace_gifts: [{id:1, price_in_cents:5000}]} }
+  let(:auth) { 'eyJ0eXAiOiJKV1QiLCJhbGciOiJTSEEyNTYifQ==.TFdWYU5VTVhzK3JFaVhHT2p5VDRHNFRsUk1ybnk2V2E4TDNDSW5meEdXdTVERUJNeHlDTEU1K216Qk1hb3Q4QlZaTVJvWndjR2ZoS01xc3gzdnZMUHdQckN1Z0kreG9rYVF3c1JjUjNkNlNLVmROQTlJb0hvMmpHdkx2REh3NXE=.cu7N3bPxGg8fPxFsIUcjyOISwn+29YpB0l7YDHwkMDg=' }
+  let(:endpoint ) { 'https://testbedapp.giftbit.com/papi/v1/'}
+  let :data do
+    {
+      message: 'Thank you for being an awesome person',
+      subject: 'Present from Community Rewards',
+      contacts: [firstname: 'Sean', lastname: 'Linsley', email: 'sean@modernmsg.com'],
+      marketplace_gifts: [id: 1, price_in_cents: 5000]
+    }
+  end
 
-  before(:each) do
+  before do
     Giftbit.endpoint = endpoint
-    Giftbit.auth = auth
   end
 
-  describe "#account" do
-    it "returns Welcome Msg with valid credentials" do
-      res = Giftbit.account
-
-      expect(res["info"]["name"]).to eql "Credentials are valid"
-    end
-
-    it "returns Unauthorized Msg with invalid credentials" do
-      Giftbit.auth = "notavalidtoken"
-      res = Giftbit.account
-
-      expect(res["text"]).to eql "Unauthorized"
-      expect(res["status"]).to eql 401
-    end
+  after do
+    Giftbit.auth  = nil
+    Giftbit.auths = nil
   end
 
-  describe "#marketplace" do
-    it "list all gifts" do
-      res = Giftbit.marketplace
-      expect(res["info"]["name"]).to eql "Marketplace Gifts Retrieved"
-    end
-
-    it "list all gifts by vendor" do
-      res = Giftbit.marketplace(vendor:6)
-      expect(res["total_count"]).to be >= 0
-    end
-
-    it "display list of gifts limits" do
-      res = Giftbit.marketplace(limit:5)
-      expect(res["total_count"]).to be >= 0
-    end
+  it 'errors without auth' do
+    expect{
+      Giftbit.account
+    }.to raise_error 'you must set an auth token at application boot'
   end
 
-  describe "#regions" do
-    it "list all regions from giftbit database" do
-      res = Giftbit.regions
-      expect(res["regions"].count).to eql 36 #TODO: make this a dynamic fetch compare
-    end
+  it 'errors without auth, but auths set' do
+    Giftbit.auths = {default: auth}
 
-    it "returns Regions Retrieved Msg" do
-      res = Giftbit.regions
-      expect(res["info"]["name"]).to eql "Marketplace Regions Retrieved"
-    end
+    expect{
+      Giftbit.account
+    }.to raise_error 'you must init a new API instance with the auth you want to use'
   end
 
-  describe "#vendors" do
-    it "list all vendors from giftbit database" do
-      res = Giftbit.vendors
-      expect(res["vendors"].count).to eql 24 #TODO: make this a dynamic fetch compare
-    end
+  it 'errors for unregistered auth' do
+    Giftbit.auths = {default: auth}
 
-    it "returns Retrieved Vendors Msg" do
-      res = Giftbit.vendors
-      expect(res["info"]["name"]).to eql "Marketplace Vendors Retrieved"
-    end
+    expect{
+      Giftbit.new(auth: :foo).account
+    }.to raise_error KeyError, 'key not found: :foo'
   end
 
-  describe "#categories" do
-    it "list all 15 categories from giftbit database" do
-      res = Giftbit.categories
-      expect(res["categories"].count).to eql 15
-    end
+  it 'errors when both auth and auths are set' do
+    Giftbit.auth  = auth
+    Giftbit.auths = {default: auth}
 
-    it "returns Retrieved Categories Msg" do
-      res = Giftbit.categories
-      expect(res["info"]["name"]).to eql "Marketplace Categories Retrieved"
-    end
+    expect{
+      Giftbit.account
+    }.to raise_error "auth and auths can't both be set"
+
+    expect{
+      Giftbit.new(auth: :default).account
+    }.to raise_error "auth and auths can't both be set"
   end
 
-  describe "#campaign" do
-    it "list all campaigns created" do
-      res = Giftbit.campaign
-      expect(res["info"]["name"]).to eql "Campaign Retrieved"
-    end
-
-    it "can fetch campaign with ID provided" do
-      data_fetch = data
-      data_fetch[:id] = "GiftbitGift#{Time.now.utc.to_i}"
-      gift = Giftbit.create_gift(data_fetch)
-
-      res = Giftbit.campaign(id: gift["info"]["id"])
-
-      expect(res["info"]["id"]).to eql gift["info"]["id"]
-      expect(res["info"]["name"]).to eql "Campaign Retrieved"
-    end
-
-    after(:all) do
-      @cp_list = Giftbit.campaign
-
-      @cp_list["campaigns"].map do |campaign|
-        if (campaign["id"].include? "GiftbitGift") && campaign["status"] == "QUOTE"
-          res = Giftbit.delete_gift(campaign["id"])
+  [:class, :instance].each do |variant|
+    describe "(#{variant})" do
+      before do |example|
+        if variant == :class
+          Giftbit.auth = example.metadata[:invalid_auth] ? 'notavalidtoken' : auth
+        else
+          Giftbit.auths = {default: auth}
+          Giftbit.auths.merge! invalid: 'notavalidtoken' if example.metadata[:invalid_auth]
         end
       end
-    end
-  end
 
-  describe "#create_gift" do
-    it "create quote for gift default" do
-      data_create = data
-      data_create[:id] = "GiftbitGift#{Time.now.utc.to_i}"
-      gift = Giftbit.create_gift(data_create)
-
-      expect(gift["info"]["name"]).to eql "Campaign Quote"
-    end
-
-    it "sends gift right away if quote is set to false " do
-      data[:id] = "GiftbitGift#{Time.now.utc.to_i}"
-      data[:quote] = false
-
-      gift = Giftbit.create_gift(data)
-
-      expect(gift["info"]["name"]).to eql "Campaign Created"
-    end
-
-    after(:all) do
-      @cp_list = Giftbit.campaign
-
-      @cp_list["campaigns"].map do |campaign|
-        if (campaign["id"].include? "GiftbitGift") && campaign["status"] == "QUOTE"
-          res = Giftbit.delete_gift(campaign["id"])
+      let :api do |example|
+        if variant == :class
+          Giftbit
+        else
+          auth = example.metadata[:invalid_auth] ? :invalid : :default
+          Giftbit.new auth: auth
         end
       end
-    end
-  end
 
-  describe "#send_gift" do
-    it "sends quoted gift with ID" do
-      data[:id] = "GiftbitGift#{Time.now.utc.to_i}"
-      data[:quote] = true
-      gift = Giftbit.create_gift(data)
+      describe '#account' do
+        it 'returns welcome message with valid credentials' do
+          res = api.account
 
-      #this is step is approval of quote gift
-      res = Giftbit.send_gift(gift["campaign"]["id"])
+          expect(res['info']['name']).to eql 'Credentials are valid'
+        end
 
-      expect(res["info"]["name"]).to eql "Campaign Created"
-    end
-  end
+        it 'returns unauthorized message with invalid credentials', invalid_auth: true do
+          res = api.account
 
-  describe "#delete_gift" do
-    it "deletes the gift with ID" do
-      data_del = data
-      data_del[:id] = "GiftbitGift#{Time.now.utc.to_i}"
-      gift = Giftbit.create_gift(data_del)
-
-      res = Giftbit.delete_gift(gift["campaign"]["id"])
-      expect(res["info"]["name"]).to eql "Campaign Deleted"
-    end
-  end
-
-  describe "#gifts" do
-    it "can fetch the gifts for a given campaign" do
-      data_create = data
-      data_create[:id] = "GiftbitGift#{Time.now.utc.to_i}"
-      data_create[:quote] = false
-      gift = Giftbit.create_gift(data_create)
-
-      sleep 30
-
-      gifts = Giftbit.gifts(campaign_uuid: gift["campaign"]["uuid"])
-      expect(gifts['gifts'].length).to be > 0
-
-      gifts['gifts'][0].tap do |g|
-        expect(g['campaign_uuid']).to eql gift["campaign"]["uuid"]
-        expect(g['status']).to eql 'SENT_AND_REDEEMABLE'
-        expect(g['delivery_status']).to eql 'DELIVERED'
-        expect(g['redeemed_date']).to eql nil
-        expect(g['management_dashboard_link']).to eql "http://testbedapp.giftbit.com/campaign/campaignInfo?uuid=#{gift["campaign"]["uuid"]}&gift_uuid=#{g["uuid"]}"
-      end
-    end
-
-    it "can re-send a email for a given campaign gift" do
-      data_create = data
-      data_create[:id] = "GiftbitGift#{Time.now.utc.to_i}"
-      data_create[:quote] = false
-      gift = Giftbit.create_gift(data_create)
-
-      sleep 30
-
-      gift, * = Giftbit.gifts(campaign_uuid: gift['campaign']['uuid'])['gifts']
-
-      res = Giftbit.resend_gift(gift['uuid'])
-
-      expect(res['info']['code']).to eql 'INFO_GIFTS_RESENT'
-    end
-
-    after(:all) do
-      @cp_list = Giftbit.campaign
-
-      @cp_list["campaigns"].map do |campaign|
-        if (campaign["id"].include? "GiftbitGift") && campaign["status"] == "QUOTE"
-          res = Giftbit.delete_gift(campaign["id"])
+          expect(res['text']).to eql 'Unauthorized'
+          expect(res['status']).to eql 401
         end
       end
-    end
-  end
 
-  describe "#get_links" do
-    it "returns link status" do
-      data_fetch = data
-      data_fetch[:id] = "GiftbitGift#{Time.now.utc.to_i}"
-      data_fetch[:delivery_type] = 'SHORTLINK'
-      gift = Giftbit.create_gift(data_fetch)
+      describe '#marketplace' do
+        it 'lists all gifts' do
+          res = api.marketplace
+          expect(res['info']['name']).to eql 'Marketplace Gifts Retrieved'
+        end
 
-      res = Giftbit.get_links(gift["campaign"]["id"])
+        it 'lists all gifts by vendor' do
+          res = api.marketplace vendor: 6
+          expect(res['total_count']).to be >= 0
+        end
+      end
 
-      expect(res["info"]["code"]).to eql "INFO_LINKS_GENERATION_IN_PROGRESS"
+      describe '#regions' do
+        it 'lists all regions' do
+          res = api.regions
+          expect(res['regions'].count).to eql 36
+        end
+
+        it 'returns Regions Retrieved message' do
+          res = api.regions
+          expect(res['info']['name']).to eql 'Marketplace Regions Retrieved'
+        end
+      end
+
+      describe '#vendors' do
+        it 'list all vendors' do
+          res = api.vendors
+          expect(res['vendors'].count).to eql 24
+        end
+
+        it 'returns Vendors Retrieved message' do
+          res = api.vendors
+          expect(res['info']['name']).to eql 'Marketplace Vendors Retrieved'
+        end
+      end
+
+      describe '#categories' do
+        it 'lists all categories' do
+          res = api.categories
+          expect(res['categories'].count).to eql 15
+        end
+
+        it 'returns Categories Retrieved message' do
+          res = api.categories
+          expect(res['info']['name']).to eql 'Marketplace Categories Retrieved'
+        end
+      end
+
+      describe '#campaign' do
+        it 'list all campaigns created' do
+          res = api.campaign
+          expect(res['campaigns'].count).to be >= 5
+          expect(res['info']['name']).to eql 'Campaign Retrieved'
+        end
+
+        it 'can fetch campaign with ID provided' do
+          data[:id] = "GiftbitGift#{Time.now.utc.to_i}"
+          gift = api.create_gift(data)
+
+          sleep 5
+
+          res = api.campaign(id: gift['info']['id'])
+
+          expect(res['info']['id']).to eql gift['info']['id']
+          expect(res['info']['name']).to eql 'Campaign Retrieved'
+        end
+
+        after  do
+          api.campaign['campaigns'].map do |campaign|
+            if campaign['id'].include?('GiftbitGift') && campaign['status'] == 'QUOTE'
+              api.delete_gift campaign['id']
+            end
+          end
+        end
+      end
+
+      describe '#create_gift' do
+        it 'create quote for gift default' do
+          data[:id] = "GiftbitGift#{Time.now.utc.to_i}"
+          gift = api.create_gift(data)
+
+          expect(gift['info']['name']).to eql 'Campaign Quote'
+        end
+
+        it 'sends gift right away if quote is set to false' do
+          data[:id]    = "GiftbitGift#{Time.now.utc.to_i}"
+          data[:quote] = false
+
+          gift = api.create_gift(data)
+
+          expect(gift['info']['name']).to eql 'Campaign Created'
+        end
+
+        after do
+          api.campaign['campaigns'].map do |campaign|
+            if (campaign['id'].include? 'GiftbitGift') && campaign['status'] == 'QUOTE'
+              api.delete_gift campaign['id']
+            end
+          end
+        end
+      end
+
+      describe '#send_gift' do
+        it 'sends quoted gift with ID' do
+          data[:id]    = "GiftbitGift#{Time.now.utc.to_i}"
+          data[:quote] = true
+          gift = api.create_gift(data)
+
+          sleep 5
+
+          res = api.send_gift(gift['campaign']['id'])
+
+          expect(res['info']['name']).to eql 'Campaign Created'
+        end
+      end
+
+      describe '#delete_gift' do
+        it 'deletes the gift with ID' do
+          data[:id] = "GiftbitGift#{Time.now.utc.to_i}"
+          gift = api.create_gift(data)
+
+          sleep 5
+
+          res = api.delete_gift(gift['campaign']['id'])
+          expect(res['info']['name']).to eql 'Campaign Deleted'
+        end
+      end
+
+      describe '#gifts' do
+        it 'can fetch the gifts for a given campaign' do
+          data[:id]    = "GiftbitGift#{Time.now.utc.to_i}"
+          data[:quote] = false
+          gift = api.create_gift(data)
+
+          sleep 15
+
+          gifts = api.gifts(campaign_uuid: gift['campaign']['uuid'])
+          expect(gifts['gifts'].length).to be > 0
+
+          gifts['gifts'][0].tap do |g|
+            expect(g['campaign_uuid']).to eql gift['campaign']['uuid']
+            expect(g['status']).to eql 'SENT_AND_REDEEMABLE'
+            expect(g['delivery_status']).to eql 'DELIVERED'
+            expect(g['redeemed_date']).to eql nil
+            expect(g['management_dashboard_link']).to eql "http://testbedapp.giftbit.com/campaign/campaignInfo?uuid=#{gift['campaign']['uuid']}&gift_uuid=#{g['uuid']}"
+          end
+        end
+
+        it 'can re-send a email for a given campaign gift' do
+          data[:id]    = "GiftbitGift#{Time.now.utc.to_i}"
+          data[:quote] = false
+          gift = api.create_gift(data)
+
+          sleep 15
+
+          gift = api.gifts(campaign_uuid: gift['campaign']['uuid'])['gifts'].first
+
+          res = api.resend_gift(gift['uuid'])
+
+          expect(res['info']['code']).to eql 'INFO_GIFTS_RESENT'
+        end
+
+        after do
+          api.campaign['campaigns'].map do |campaign|
+            if campaign['id'].include?('GiftbitGift') && campaign['status'] == 'QUOTE'
+              api.delete_gift campaign['id']
+            end
+          end
+        end
+      end
+
+      describe '#get_links' do
+        it 'returns link status' do
+          data[:id]            = "GiftbitGift#{Time.now.utc.to_i}"
+          data[:delivery_type] = 'SHORTLINK'
+          gift = api.create_gift(data)
+
+          sleep 5
+
+          res = api.get_links(gift['campaign']['id'])
+
+          expect(res['info']['code']).to eql 'INFO_LINKS_GENERATION_IN_PROGRESS'
+        end
+      end
     end
   end
 end

--- a/spec/giftbit_spec.rb
+++ b/spec/giftbit_spec.rb
@@ -225,7 +225,7 @@ describe Giftbit do
           data[:quote] = false
           gift = api.create_gift(data)
 
-          sleep 15
+          sleep 30
 
           gifts = api.gifts(campaign_uuid: gift['campaign']['uuid'])
           expect(gifts['gifts'].length).to be > 0
@@ -239,7 +239,7 @@ describe Giftbit do
           end
         end
 
-        it 'can re-send a email for a given campaign gift' do
+        it 'can re-send an email for a given campaign gift' do
           data[:id]    = "GiftbitGift#{Time.now.utc.to_i}"
           data[:quote] = false
           gift = api.create_gift(data)

--- a/spec/giftbit_spec.rb
+++ b/spec/giftbit_spec.rb
@@ -56,6 +56,21 @@ describe Giftbit do
     }.to raise_error "auth and auths can't both be set"
   end
 
+  it '.each_auth' do
+    Giftbit.auths = {default: auth, custom: 'foo'}
+
+    times_called = 0
+
+    Giftbit.each_auth do |api|
+      times_called += 1
+
+      expect(api).to be_an_instance_of Giftbit
+      expect([auth, 'foo']).to include api.auth
+    end
+
+    expect(times_called).to eq 2
+  end
+
   [:class, :instance].each do |variant|
     describe "(#{variant})" do
       before do |example|
@@ -186,7 +201,7 @@ describe Giftbit do
 
         after do
           api.campaign['campaigns'].map do |campaign|
-            if (campaign['id'].include? 'GiftbitGift') && campaign['status'] == 'QUOTE'
+            if campaign['id'].include?('GiftbitGift') && campaign['status'] == 'QUOTE'
               api.delete_gift campaign['id']
             end
           end

--- a/spec/giftbit_spec.rb
+++ b/spec/giftbit_spec.rb
@@ -2,7 +2,6 @@ require 'giftbit'
 
 describe Giftbit do
   let(:auth) { 'eyJ0eXAiOiJKV1QiLCJhbGciOiJTSEEyNTYifQ==.TFdWYU5VTVhzK3JFaVhHT2p5VDRHNFRsUk1ybnk2V2E4TDNDSW5meEdXdTVERUJNeHlDTEU1K216Qk1hb3Q4QlZaTVJvWndjR2ZoS01xc3gzdnZMUHdQckN1Z0kreG9rYVF3c1JjUjNkNlNLVmROQTlJb0hvMmpHdkx2REh3NXE=.cu7N3bPxGg8fPxFsIUcjyOISwn+29YpB0l7YDHwkMDg=' }
-  let(:endpoint ) { 'https://testbedapp.giftbit.com/papi/v1/'}
   let :data do
     {
       message: 'Thank you for being an awesome person',
@@ -10,10 +9,6 @@ describe Giftbit do
       contacts: [firstname: 'Sean', lastname: 'Linsley', email: 'sean@modernmsg.com'],
       marketplace_gifts: [id: 1, price_in_cents: 5000]
     }
-  end
-
-  before do
-    Giftbit.endpoint = endpoint
   end
 
   after do


### PR DESCRIPTION
This PR refactors the code so that it can be applied to either the class, e.g. `Giftbit.account`, or to a specific account when you have many, e.g. `Giftbit.new(auth: :special).account`.

This new behavior can only be accessed when using the new `auths` setting:
```ruby
Giftbit.auths = {default: 'foo', special: 'bar'}
```